### PR TITLE
I rename translator API "translation" to "translator" because ...

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ app.get('/token', function(req, res) {
 app.use(bodyParser.urlencoded({ extended: false }));
 
 var mt_credentials = extend({
-  url: 'https://gateway.watsonplatform.net/language-translation/api',
+  url: 'https://gateway.watsonplatform.net/language-translator/api',
   username: 'user name to access MT service',
   password: 'password to access MT service',
   version: 'v2'

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ declared-services:
     label: speech_to_text
     plan: standard
   language-translation-service:
-    label: language_translation
+    label: language_translator
     plan: standard
   text-to-speech-service:
     label: text_to_speech


### PR DESCRIPTION
IBM renamed the API recently.

Fixed by Taiji IBM Developer Advocate in Japan